### PR TITLE
unlock version of bcrypt-ruby

### DIFF
--- a/typus.gemspec
+++ b/typus.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bcrypt-ruby", "~> 3.0.1"
+  spec.add_dependency "bcrypt-ruby"
   spec.add_dependency "jquery-rails"
   spec.add_dependency "rails", "~> 4.2.0"
 end


### PR DESCRIPTION
Unlock version of bcrypt-ruby to upgrade ruby to 2.6